### PR TITLE
Add endpoint for reserving domain

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -153,6 +153,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GeneralResellerNotFound'
+  /{resellerID}/domains/{domainName}/reserve:
+    post:
+      summary: Reverse free domain name for period of time
+      description: Reverse free domain name for external user identifier. Usually it's a user identifier or email in a resellers system. Domain name becomes unavailable for selling and claiming to anyone except identity that reserved the domain. Only one domain could be reserved per externalUserId. Reserve time is 168 hours.
+      security:
+        - ApiSecret: []
+      parameters:
+      - name: resellerID
+        in: path
+        description: Resellers ID obtained from UD team after registration as a Reseller
+        required: true
+        schema:
+          type: string
+          example: reseller1342
+      - name: domainName
+        in: path
+        required: true
+        schema:
+          type: string
+          example: beresnev.crypto
+      tags:
+        - domains
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DomainReverseRequest'    
+      responses:
+        '200':
+          description: Valid
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '401':
+          description: Reseller not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralResellerNotFound'
   /{resellerID}/orders:
     parameters:
       - name: resellerID
@@ -242,6 +285,13 @@ paths:
                 $ref: '#/components/schemas/GeneralNotFoundError'
 components:
   schemas:
+    DomainReverseRequest:
+      type: object
+      properties:
+        externalUserId:
+          type: string
+          example: 'example@user.com'
+          description: 'Unique external identifier of user. Could by ANY string value. Unstoppable will try to match internal and external user id.'
     FreePayment:
       type: object
       properties:
@@ -289,6 +339,10 @@ components:
                 example:
                   crypto.ETH.address: '0x6EC0DEeD30605Bcd19342f3c30201DB263291589'
                   crypto.BTC.address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
+              externalUserId: 
+                type: string
+                nullable: true
+                description: Field is required if domain was reserved. Value should be the same as it was when domain was reserved.
     DomainOrderResponse:
       type: object
       properties:


### PR DESCRIPTION
Reverse free domain name for external user identifier. Usually it's a user identifier or email in a resellers system. Domain name becomes unavailable for selling and claiming to anyone except identity that reserved the domain. Only one domain could be reserved per externalUserId. Reserve time is 168 hours.